### PR TITLE
#37 Migrate from rpc_accounting to influxdb

### DIFF
--- a/entities/src/rpc_accounting.rs
+++ b/entities/src/rpc_accounting.rs
@@ -40,6 +40,7 @@ pub struct Model {
     pub max_response_bytes: u64,
     pub archive_request: bool,
     pub origin: Option<String>,
+    pub migrated: Option<DateTime>
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/scripts/manual-tests/21-sql-migration-make-backup.sh
+++ b/scripts/manual-tests/21-sql-migration-make-backup.sh
@@ -1,0 +1,1 @@
+mysqldump -u root --password=dev_web3_proxy -h 127.0.0.1 --port 13306

--- a/scripts/manual-tests/21-sql-migration-verify-test-queries.sql
+++ b/scripts/manual-tests/21-sql-migration-verify-test-queries.sql
@@ -1,0 +1,17 @@
+SELECT COUNT(*) FROM rpc_accounting WHERE migrated IS NULL;
+UPDATE rpc_accounting SET migrated = NULL;
+
+SELECT SUM(frontend_requests) FROM rpc_accounting;
+SELECT SUM(frontend_requests) FROM rpc_accounting_v2;
+
+SELECT SUM(backend_requests) FROM rpc_accounting;
+SELECT SUM(backend_requests) FROM rpc_accounting_v2;
+
+SELECT SUM(sum_request_bytes) FROM rpc_accounting;
+SELECT SUM(sum_request_bytes) FROM rpc_accounting_v2;
+
+SELECT SUM(sum_response_millis) FROM rpc_accounting;
+SELECT SUM(sum_response_millis) FROM rpc_accounting_v2;
+
+SELECT SUM(sum_response_bytes) FROM rpc_accounting;
+SELECT SUM(sum_response_bytes) FROM rpc_accounting_v2;

--- a/web3_proxy/src/app/mod.rs
+++ b/web3_proxy/src/app/mod.rs
@@ -67,7 +67,7 @@ pub static APP_USER_AGENT: &str = concat!(
 );
 
 // aggregate across 1 week
-const BILLING_PERIOD_SECONDS: i64 = 60 * 60 * 24 * 7;
+pub const BILLING_PERIOD_SECONDS: i64 = 60 * 60 * 24 * 7;
 
 #[derive(Debug, From)]
 struct ResponseCacheKey {
@@ -575,7 +575,12 @@ impl Web3ProxyApp {
         // stats can be saved in mysql, influxdb, both, or none
         let stat_sender = if let Some(emitter_spawn) = StatBuffer::try_spawn(
             top_config.app.chain_id,
-            top_config.app.influxdb_bucket.clone().context("No influxdb bucket was provided")?.to_owned(),
+            top_config
+                .app
+                .influxdb_bucket
+                .clone()
+                .context("No influxdb bucket was provided")?
+                .to_owned(),
             db_conn.clone(),
             influxdb_client.clone(),
             60,
@@ -812,26 +817,27 @@ impl Web3ProxyApp {
 
             app_handles.push(config_handle);
         }
-// =======
-//         if important_background_handles.is_empty() {
-//             info!("no important background handles");
-//
-//             let f = tokio::spawn(async move {
-//                 let _ = background_shutdown_receiver.recv().await;
-//
-//                 Ok(())
-//             });
-//
-//             important_background_handles.push(f);
-// >>>>>>> 77df3fa (stats v2)
+        // =======
+        //         if important_background_handles.is_empty() {
+        //             info!("no important background handles");
+        //
+        //             let f = tokio::spawn(async move {
+        //                 let _ = background_shutdown_receiver.recv().await;
+        //
+        //                 Ok(())
+        //             });
+        //
+        //             important_background_handles.push(f);
+        // >>>>>>> 77df3fa (stats v2)
 
         Ok((
             app,
             app_handles,
             important_background_handles,
             new_top_config_sender,
-            consensus_connections_watcher
-        ).into())
+            consensus_connections_watcher,
+        )
+            .into())
     }
 
     pub async fn apply_top_config(&self, new_top_config: TopConfig) -> anyhow::Result<()> {

--- a/web3_proxy/src/app/mod.rs
+++ b/web3_proxy/src/app/mod.rs
@@ -1799,7 +1799,7 @@ impl Web3ProxyApp {
 
                 if let Some(stat_sender) = self.stat_sender.as_ref() {
                     let response_stat = RpcQueryStats::new(
-                        method.to_string(),
+                        Some(method.to_string()),
                         authorization.clone(),
                         request_metadata,
                         response.num_bytes(),
@@ -1822,7 +1822,7 @@ impl Web3ProxyApp {
 
         if let Some(stat_sender) = self.stat_sender.as_ref() {
             let response_stat = RpcQueryStats::new(
-                request_method,
+                Some(request_method),
                 authorization.clone(),
                 request_metadata,
                 response.num_bytes(),

--- a/web3_proxy/src/app/ws.rs
+++ b/web3_proxy/src/app/ws.rs
@@ -96,7 +96,7 @@ impl Web3ProxyApp {
 
                         if let Some(stat_sender) = stat_sender.as_ref() {
                             let response_stat = RpcQueryStats::new(
-                                "eth_subscription(newHeads)".to_string(),
+                                Some("eth_subscription(newHeads)".to_string()),
                                 authorization.clone(),
                                 request_metadata.clone(),
                                 response_bytes,
@@ -167,7 +167,7 @@ impl Web3ProxyApp {
 
                         if let Some(stat_sender) = stat_sender.as_ref() {
                             let response_stat = RpcQueryStats::new(
-                                "eth_subscription(newPendingTransactions)".to_string(),
+                                Some("eth_subscription(newPendingTransactions)".to_string()),
                                 authorization.clone(),
                                 request_metadata.clone(),
                                 response_bytes,
@@ -243,7 +243,7 @@ impl Web3ProxyApp {
 
                         if let Some(stat_sender) = stat_sender.as_ref() {
                             let response_stat = RpcQueryStats::new(
-                                "eth_subscription(newPendingFullTransactions)".to_string(),
+                                Some("eth_subscription(newPendingFullTransactions)".to_string()),
                                 authorization.clone(),
                                 request_metadata.clone(),
                                 response_bytes,
@@ -319,7 +319,7 @@ impl Web3ProxyApp {
 
                         if let Some(stat_sender) = stat_sender.as_ref() {
                             let response_stat = RpcQueryStats::new(
-                                "eth_subscription(newPendingRawTransactions)".to_string(),
+                                Some("eth_subscription(newPendingRawTransactions)".to_string()),
                                 authorization.clone(),
                                 request_metadata.clone(),
                                 response_bytes,
@@ -350,7 +350,7 @@ impl Web3ProxyApp {
 
         if let Some(stat_sender) = self.stat_sender.as_ref() {
             let response_stat = RpcQueryStats::new(
-                request_json.method.clone(),
+                Some(request_json.method.clone()),
                 authorization.clone(),
                 request_metadata,
                 response.num_bytes(),

--- a/web3_proxy/src/bin/web3_proxy_cli/main.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/main.rs
@@ -374,12 +374,17 @@ fn main() -> anyhow::Result<()> {
                 x.main(&db_conn).await
             }
             SubCommand::MigrateStatsToV2(x) => {
+
+                let top_config = top_config.expect("--config is required to run the migration from stats-mysql to stats-influx");
+                // let top_config_path =
+                //     top_config_path.expect("path must be set if top_config exists");
+
                 let db_url = cli_config
                     .db_url
                     .expect("'--config' (with a db) or '--db-url' is required to run the migration from stats-mysql to stats-influx");
 
                 let db_conn = get_db(db_url, 1, 1).await?;
-                x.main(&db_conn).await
+                x.main(top_config, &db_conn).await
             }
             SubCommand::Pagerduty(x) => {
                 if cli_config.sentry_url.is_none() {

--- a/web3_proxy/src/bin/web3_proxy_cli/migrate_stats_to_v2.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/migrate_stats_to_v2.rs
@@ -116,8 +116,6 @@ impl MigrateStatsToV2 {
             None
         };
 
-        info!("Background handles are: {:?}", important_background_handles);
-
         // Basically spawn the full app, look at web3_proxy CLI
 
         while true {
@@ -134,10 +132,6 @@ impl MigrateStatsToV2 {
             }
 
             // (2) Create request metadata objects to match the old data
-            let mut global_timeseries_buffer = HashMap::<RpcQueryKey, BufferedRpcQueryStats>::new();
-            let mut opt_in_timeseries_buffer = HashMap::<RpcQueryKey, BufferedRpcQueryStats>::new();
-            let mut accounting_db_buffer = HashMap::<RpcQueryKey, BufferedRpcQueryStats>::new();
-
             // Iterate through all old rows, and put them into the above objects.
             for x in old_records.iter() {
                 info!("Preparing for migration: {:?}", x);
@@ -212,6 +206,7 @@ impl MigrateStatsToV2 {
                     // (3) Send through a channel to a stat emitter
                     // Send it to the stats sender
                     if let Some(stat_sender_ref) = stat_sender.as_ref() {
+                        info!("Method is: {:?}", x.clone().method.unwrap());
                         let mut response_stat = RpcQueryStats::new(
                             x.clone().method.unwrap(),
                             authorization.clone(),
@@ -253,6 +248,8 @@ impl MigrateStatsToV2 {
             // Only after this mark all the items as processed / completed
 
             // If the items are in rpc_v2, delete the initial items from the database
+
+            // return Ok(());
 
             // (4) Update the batch in the old table with the current timestamp (Mark the batch as migrated)
             let old_record_ids = old_records.iter().map(|x| x.id);

--- a/web3_proxy/src/bin/web3_proxy_cli/migrate_stats_to_v2.rs
+++ b/web3_proxy/src/bin/web3_proxy_cli/migrate_stats_to_v2.rs
@@ -1,18 +1,49 @@
-use std::net::{IpAddr, Ipv4Addr};
-use std::num::NonZeroU64;
 use anyhow::Context;
 use argh::FromArgs;
-use entities::{rpc_key, rpc_accounting, rpc_accounting_v2, user};
+use chrono::{DateTime, Utc};
+use entities::{rpc_accounting, rpc_accounting_v2, rpc_key, user};
 use ethers::types::Address;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
 use hashbrown::HashMap;
-use log::{debug, info, warn};
+use log::{debug, error, info, trace, warn};
 use migration::sea_orm::{
     self, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
-    QueryFilter, QuerySelect
+    QueryFilter, QuerySelect, UpdateResult,
 };
-use web3_proxy::app::AuthorizationChecks;
-use web3_proxy::frontend::authorization::{Authorization, AuthorizationType, RequestMetadata, RpcSecretKey};
-use web3_proxy::stats::{BufferedRpcQueryStats, RpcQueryKey};
+use migration::{Expr, Value};
+use std::mem::swap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+use tokio::time::{sleep, Instant};
+use web3_proxy::app::{AuthorizationChecks, Web3ProxyApp, BILLING_PERIOD_SECONDS};
+use web3_proxy::config::TopConfig;
+use web3_proxy::frontend::authorization::{
+    Authorization, AuthorizationType, RequestMetadata, RpcSecretKey,
+};
+use web3_proxy::stats::{BufferedRpcQueryStats, RpcQueryKey, RpcQueryStats, StatBuffer};
+
+// Helper function to go from DateTime to Instant
+fn datetime_utc_to_instant(datetime: DateTime<Utc>) -> anyhow::Result<Instant> {
+    let epoch = datetime.timestamp(); // Get the Unix timestamp
+    let nanos = datetime.timestamp_subsec_nanos();
+
+    let duration_since_epoch = Duration::new(epoch as u64, nanos);
+    // let duration_since_datetime = Duration::new(, nanos);
+    let instant_new = Instant::now();
+    warn!("Instant new is: {:?}", instant_new);
+    let unix_epoch = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    warn!("Instant since unix epoch is: {:?}", unix_epoch);
+
+    instant_new
+        .checked_sub(unix_epoch)
+        .context("Could not subtract unix epoch from instant now")?
+        .checked_add(duration_since_epoch)
+        .context("Could not add duration since epoch for updated time")
+}
 
 /// change a user's address.
 #[derive(FromArgs, PartialEq, Eq, Debug)]
@@ -20,14 +51,80 @@ use web3_proxy::stats::{BufferedRpcQueryStats, RpcQueryKey};
 pub struct MigrateStatsToV2 {}
 
 impl MigrateStatsToV2 {
-    pub async fn main(self, db_conn: &DatabaseConnection) -> anyhow::Result<()> {
+    pub async fn main(
+        self,
+        top_config: TopConfig,
+        db_conn: &DatabaseConnection,
+    ) -> anyhow::Result<()> {
+        // Also add influxdb container ...
+        // let mut spawned_app =
+        //     Web3ProxyApp::spawn(top_config.clone(), 2, app_shutdown_sender.clone()).await?;
+
+        // we wouldn't really need this, but let's spawn this anyways
+        // easier than debugging the rest I suppose
+        let (app_shutdown_sender, _app_shutdown_receiver) = broadcast::channel(1);
+        let rpc_account_shutdown_recevier = app_shutdown_sender.subscribe();
+
+        // we must wait for these to end on their own (and they need to subscribe to shutdown_sender)
+        let mut important_background_handles = FuturesUnordered::new();
+
+        // Spawn the influxdb
+        let influxdb_client = match top_config.app.influxdb_host.as_ref() {
+            Some(influxdb_host) => {
+                let influxdb_org = top_config
+                    .app
+                    .influxdb_org
+                    .clone()
+                    .expect("influxdb_org needed when influxdb_host is set");
+                let influxdb_token = top_config
+                    .app
+                    .influxdb_token
+                    .clone()
+                    .expect("influxdb_token needed when influxdb_host is set");
+
+                let influxdb_client =
+                    influxdb2::Client::new(influxdb_host, influxdb_org, influxdb_token);
+
+                // TODO: test the client now. having a stat for "started" can be useful on graphs to mark deploys
+
+                Some(influxdb_client)
+            }
+            None => None,
+        };
+
+        // Spawn the stat-sender
+        let stat_sender = if let Some(emitter_spawn) = StatBuffer::try_spawn(
+            top_config.app.chain_id,
+            top_config
+                .app
+                .influxdb_bucket
+                .clone()
+                .context("No influxdb bucket was provided")?
+                .to_owned(),
+            Some(db_conn.clone()),
+            influxdb_client.clone(),
+            30,
+            1,
+            BILLING_PERIOD_SECONDS,
+            rpc_account_shutdown_recevier,
+        )? {
+            // since the database entries are used for accounting, we want to be sure everything is saved before exiting
+            important_background_handles.push(emitter_spawn.background_handle);
+
+            Some(emitter_spawn.stat_sender)
+        } else {
+            None
+        };
+
+        info!("Background handles are: {:?}", important_background_handles);
+
+        // Basically spawn the full app, look at web3_proxy CLI
 
         while true {
-
             // (1) Load a batch of rows out of the old table until no more rows are left
             let old_records = rpc_accounting::Entity::find()
                 .filter(rpc_accounting::Column::Migrated.is_null())
-                .limit(10000)
+                .limit(2)
                 .all(db_conn)
                 .await?;
             if old_records.len() == 0 {
@@ -42,8 +139,7 @@ impl MigrateStatsToV2 {
             let mut accounting_db_buffer = HashMap::<RpcQueryKey, BufferedRpcQueryStats>::new();
 
             // Iterate through all old rows, and put them into the above objects.
-            for x in old_records {
-
+            for x in old_records.iter() {
                 info!("Preparing for migration: {:?}", x);
 
                 // TODO: Split up a single request into multiple requests ...
@@ -57,103 +153,163 @@ impl MigrateStatsToV2 {
                             .filter(rpc_key::Column::Id.eq(rpc_key_id))
                             .one(db_conn)
                             .await?
-                            .unwrap();
+                            .context("Could not find rpc_key_obj for the given rpc_key_id")?;
 
                         // TODO: Create authrization
                         // We can probably also randomly generate this, as we don't care about the user (?)
                         AuthorizationChecks {
                             user_id: rpc_key_obj.user_id,
                             rpc_secret_key: Some(RpcSecretKey::Uuid(rpc_key_obj.secret_key)),
-                            rpc_secret_key_id: Some(NonZeroU64::new(rpc_key_id).unwrap()),
-                            ..Default::default()
-                        }
-                    },
-                    None => {
-                        AuthorizationChecks {
+                            rpc_secret_key_id: Some(
+                                NonZeroU64::new(rpc_key_id)
+                                    .context("Could not use rpc_key_id to create a u64")?,
+                            ),
                             ..Default::default()
                         }
                     }
+                    None => AuthorizationChecks {
+                        ..Default::default()
+                    },
                 };
 
                 // Then overwrite rpc_key_id and user_id (?)
                 let authorization_type = AuthorizationType::Frontend;
-                let authorization = Authorization::try_new(
-                    authorization_checks,
-                    None,
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    None,
-                    None,
-                    None,
-                    authorization_type
+                let authorization = Arc::new(
+                    Authorization::try_new(
+                        authorization_checks,
+                        None,
+                        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                        None,
+                        None,
+                        None,
+                        authorization_type,
+                    )
+                    .context("Initializing Authorization Struct was not successful")?,
                 );
 
                 // It will be like a fork basically (to simulate getting multiple single requests ...)
                 // Iterate through all frontend requests
                 // For each frontend request, create one object that will be emitted (make sure the timestamp is new)
+                let n = x.frontend_requests;
 
-                for _ in 1..x.frontend_requests {
-                    info!("Creating a new frontend request");
+                for _ in 1..n {
+                    // info!("Creating a new frontend request");
 
                     // TODO: Create RequestMetadata
                     let request_metadata = RequestMetadata {
-                        start_instant: x.period_datetime.timestamp(),
-                        request_bytes: x.request_bytes,
-                        archive_request: x.archive_request,
-                        backend_requests: todo!(),
-                        no_servers: 0,  // This is not relevant in the new version
-                        error_response: x.error_response,
-                        response_bytes: todo!(),
-                        response_millis: todo!(),
-                        response_from_backup_rpc: todo!() // I think we did not record this back then // Default::default()
+                        start_instant: Instant::now(), // This is overwritten later on
+                        request_bytes: (x.sum_request_bytes / n).into(), // Get the mean of all the request bytes
+                        archive_request: x.archive_request.into(),
+                        backend_requests: Default::default(), // This is not used, instead we modify the field later
+                        no_servers: 0.into(), // This is not relevant in the new version
+                        error_response: x.error_response.into(),
+                        response_bytes: (x.sum_response_bytes / n).into(),
+                        response_millis: (x.sum_response_millis / n).into(),
+                        // We just don't have this data
+                        response_from_backup_rpc: false.into(), // I think we did not record this back then // Default::default()
                     };
 
+                    // (3) Send through a channel to a stat emitter
+                    // Send it to the stats sender
+                    if let Some(stat_sender_ref) = stat_sender.as_ref() {
+                        let mut response_stat = RpcQueryStats::new(
+                            x.clone().method.unwrap(),
+                            authorization.clone(),
+                            Arc::new(request_metadata),
+                            (x.sum_response_bytes / n)
+                                .try_into()
+                                .context("sum bytes average is not calculated properly")?,
+                        );
+                        // Modify the timestamps ..
+                        response_stat.modify_struct(
+                            (x.sum_response_millis / n),
+                            x.period_datetime.timestamp(), // I suppose timestamp is millis as well ... should check this in the database
+                            (x.backend_requests / n),
+                        );
+                        info!("Sending stats: {:?}", response_stat);
+                        stat_sender_ref
+                            // .send(response_stat.into())
+                            .send_async(response_stat.into())
+                            .await
+                            .context("stat_sender sending response_stat")?;
+                        info!("Send! {:?}", stat_sender);
+                    } else {
+                        panic!("Stat sender was not spawned!");
+                    }
+
+                    // Create a new stats object
+                    // Add it to the StatBuffer
                 }
 
-
+                // Let the stat_sender spawn / flush ...
+                // spawned_app.app.stat_sender.aggregate_and_save_loop()
+                // Send a signal to save ...
             }
 
-            // (N-1) Mark the batch as migrated
-            break;
+            // (3) Await that all items are properly processed
+            // TODO: Await all the background handles
+            info!("Waiting for a second until all is flushed");
 
+            // Only after this mark all the items as processed / completed
+
+            // If the items are in rpc_v2, delete the initial items from the database
+
+            // (4) Update the batch in the old table with the current timestamp (Mark the batch as migrated)
+            let old_record_ids = old_records.iter().map(|x| x.id);
+            let update_result: UpdateResult = rpc_accounting::Entity::update_many()
+                .col_expr(
+                    rpc_accounting::Column::Migrated,
+                    Expr::value(Value::ChronoDateTimeUtc(Some(Box::new(
+                        chrono::offset::Utc::now(),
+                    )))),
+                )
+                .filter(rpc_accounting::Column::Id.is_in(old_record_ids))
+                // .set(pear)
+                .exec(db_conn)
+                .await?;
+
+            info!("Update result is: {:?}", update_result);
+
+            // (N-1) Mark the batch as migrated
         }
 
+        info!(
+            "Background handles (2) are: {:?}",
+            important_background_handles
+        );
 
+        // Drop the handle
+        // Send the shutdown signal here (?)
+        // important_background_handles.clear();
 
+        // Finally also send a shutdown signal
+        match app_shutdown_sender.send(()) {
+            Err(x) => {
+                panic!("Could not send shutdown signal! {:?}", x);
+            }
+            _ => {}
+        };
 
+        // Drop the background handle
+        while let Some(x) = important_background_handles.next().await {
+            info!("Returned item is: {:?}", x);
+            match x {
+                Err(e) => {
+                    error!("{:?}", e);
+                }
+                Ok(Err(e)) => {
+                    error!("{:?}", e);
+                }
+                Ok(Ok(_)) => {
+                    // TODO: how can we know which handle exited?
+                    info!("a background handle exited");
+                    // Pop it in this case?
+                    continue;
+                }
+            }
+        }
 
-        // (3) Update the batch in the old table with the current timestamp
-
-        // (4) Send through a channel to a stat emitter
-
-
-
-        // let old_address: Address = self.old_address.parse()?;
-        // let new_address: Address = self.new_address.parse()?;
-        //
-        // let old_address: Vec<u8> = old_address.to_fixed_bytes().into();
-        // let new_address: Vec<u8> = new_address.to_fixed_bytes().into();
-        //
-        // let u = user::Entity::find()
-        //     .filter(user::Column::Address.eq(old_address))
-        //     .one(db_conn)
-        //     .await?
-        //     .context("No user found with that address")?;
-        //
-        // debug!("initial user: {:#?}", u);
-        //
-        // if u.address == new_address {
-        //     info!("user already has this address");
-        // } else {
-        //     let mut u = u.into_active_model();
-        //
-        //     u.address = sea_orm::Set(new_address);
-        //
-        //     let u = u.save(db_conn).await?;
-        //
-        //     info!("changed user address");
-        //
-        //     debug!("updated user: {:#?}", u);
-        // }
+        info!("Here (?)");
 
         Ok(())
     }

--- a/web3_proxy/src/frontend/rpc_proxy_ws.rs
+++ b/web3_proxy/src/frontend/rpc_proxy_ws.rs
@@ -400,7 +400,7 @@ async fn handle_socket_payload(
 
                     if let Some(stat_sender) = app.stat_sender.as_ref() {
                         let response_stat = RpcQueryStats::new(
-                            json_request.method.clone(),
+                            Some(json_request.method.clone()),
                             authorization.clone(),
                             request_metadata,
                             response.num_bytes(),

--- a/web3_proxy/src/stats/mod.rs
+++ b/web3_proxy/src/stats/mod.rs
@@ -40,6 +40,7 @@ pub struct RpcQueryStats {
     pub error_response: bool,
     pub request_bytes: u64,
     /// if backend_requests is 0, there was a cache_hit
+    // pub frontend_request: u64,
     pub backend_requests: u64,
     pub response_bytes: u64,
     pub response_millis: u64,

--- a/web3_proxy/src/stats/mod.rs
+++ b/web3_proxy/src/stats/mod.rs
@@ -364,7 +364,7 @@ impl RpcQueryStats {
         method: String,
         authorization: Arc<Authorization>,
         metadata: Arc<RequestMetadata>,
-        response_bytes: usize
+        response_bytes: usize,
     ) -> Self {
         // TODO: try_unwrap the metadata to be sure that all the stats for this request have been collected
         // TODO: otherwise, i think the whole thing should be in a single lock that we can "reset" when a stat is created
@@ -396,13 +396,12 @@ impl RpcQueryStats {
         &mut self,
         response_millis: u64,
         response_timestamp: i64,
-        backend_requests: u64
+        backend_requests: u64,
     ) {
         self.response_millis = response_millis;
         self.response_timestamp = response_timestamp;
         self.backend_requests = backend_requests;
     }
-
 }
 
 impl StatBuffer {
@@ -446,7 +445,6 @@ impl StatBuffer {
         stat_receiver: flume::Receiver<AppStat>,
         mut shutdown_receiver: broadcast::Receiver<()>,
     ) -> anyhow::Result<()> {
-        info!("Aggregate and save loop is running");
         let mut tsdb_save_interval =
             interval(Duration::from_secs(self.tsdb_save_interval_seconds as u64));
         let mut db_save_interval =
@@ -561,13 +559,7 @@ impl StatBuffer {
 
             for (key, stat) in global_timeseries_buffer.drain() {
                 if let Err(err) = stat
-                    .save_timeseries(
-                        &bucket,
-                        "global_proxy",
-                        self.chain_id,
-                        influxdb_client,
-                        key,
-                    )
+                    .save_timeseries(&bucket, "global_proxy", self.chain_id, influxdb_client, key)
                     .await
                 {
                     error!(
@@ -584,13 +576,7 @@ impl StatBuffer {
 
             for (key, stat) in opt_in_timeseries_buffer.drain() {
                 if let Err(err) = stat
-                    .save_timeseries(
-                        &bucket,
-                        "opt_in_proxy",
-                        self.chain_id,
-                        influxdb_client,
-                        key,
-                    )
+                    .save_timeseries(&bucket, "opt_in_proxy", self.chain_id, influxdb_client, key)
                     .await
                 {
                     error!(


### PR DESCRIPTION
References https://github.com/llamanodes/web3-proxy/issues/37

Addin CLI for the migration

- Adds a column for migration in the table `rpc_accounting`
- Reads, processes and inserts them batch-wise into `rpc_accounting_v2` and the influxdb database, by calling the built-in stats_sender / stats_emitter
